### PR TITLE
fix: change route for openlogo logo in openlogo repo

### DIFF
--- a/templates/openlogo/ForgotPassword.html
+++ b/templates/openlogo/ForgotPassword.html
@@ -18,7 +18,7 @@
     <tr>
       <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
         <a href="https://logoexecutive.vercel.app/home" style="color: rgb(17, 24, 39); text-decoration: none;">
-          <img src="https://raw.githubusercontent.com/TeamShiksha/openlogo/f5d16c9aea094606885d229db8ab4347d7034fa4/packages/ui/public/openlogo.svg"
+          <img src="https://raw.githubusercontent.com/TeamShiksha/openlogo/f5d16c9aea094606885d229db8ab4347d7034fa4/packages/ui/public/openlogo.png"
             alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
           <span style="font-size: 24px; font-weight: 800;">OpenLogo</span>
         </a>

--- a/templates/openlogo/Respond.html
+++ b/templates/openlogo/Respond.html
@@ -18,7 +18,7 @@
     <tr>
       <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
         <a href="https://logoexecutive.vercel.app/home" style="color: rgb(17, 24, 39); text-decoration: none;">
-          <img src="https://raw.githubusercontent.com/TeamShiksha/openlogo/f5d16c9aea094606885d229db8ab4347d7034fa4/packages/ui/public/openlogo.svg"
+          <img src="https://raw.githubusercontent.com/TeamShiksha/openlogo/f5d16c9aea094606885d229db8ab4347d7034fa4/packages/ui/public/openlogo.png"
             alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
           <span style="font-size: 24px; font-weight: 800;">OpenLogo</span>
         </a>

--- a/templates/openlogo/Verify.html
+++ b/templates/openlogo/Verify.html
@@ -18,7 +18,7 @@
     <tr>
       <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
         <a href="https://logoexecutive.vercel.app/home" style="color: rgb(17, 24, 39); text-decoration: none;">
-          <img src="https://raw.githubusercontent.com/TeamShiksha/openlogo/f5d16c9aea094606885d229db8ab4347d7034fa4/packages/ui/public/openlogo.svg"
+          <img src="https://raw.githubusercontent.com/TeamShiksha/openlogo/f5d16c9aea094606885d229db8ab4347d7034fa4/packages/ui/public/openlogo.png"
             alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
           <span style="font-size: 24px; font-weight: 800;">OpenLogo</span>
         </a>


### PR DESCRIPTION
## Description
Correct the path for openlogo SVG formatted image to PNG.

## Issue
Openlogo logo not rendering on mails as gmail email service does not support SVG formatted media.

## Fix
Replace SVG formatted image route with PNG formatted image route

## What type of PR is this? (Check all applicable)
- [x] 🐛 Bug Fix


