### PR TITLE
fix(email): send iCal invite as attachment instead of data URI

### DIFF
--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -9,6 +9,8 @@ import botocore.exceptions
 
 from app.utils import EmailSender, SESEmailSender
 from app.schemas.email import SendEmailRequestBody, EmailProvider
+import base64
+import urllib.parse
 
 
 class EmailService:
@@ -34,10 +36,88 @@ class EmailService:
                 - "error": Error message if the email sending fails.
         """
         try:
+            if email_details.id == 5 and 'iCalendarLink' in email_details.body:
+                ics_content = self._extract_ics_from_data_url(
+                    email_details.body.get('iCalendarLink', '')
+                )
+                if ics_content:
+                    event_name = email_details.body.get('eventName', 'event')
+                    result = self._send_email_with_ics_attachment(
+                        email_details, body, event_name, ics_content
+                    )
+                    return result
             result = self._send_email_by_provider(email_details, body)
             return result
         except Exception as error:
             self._handle_email_error(error)
+
+    def _extract_ics_from_data_url(self, data_url: str) -> str | None:
+        """
+        Extract ICS content from data URL.
+        Handles formats like: data:text/calendar;charset=utf-8,BEGIN:VCALENDAR...
+        """
+        if not data_url or not data_url.startswith('data:'):
+            return None
+
+        try:
+            header, data = data_url.split(',', 1)
+
+            if 'base64' in header:
+                decoded = base64.b64decode(data).decode('utf-8')
+            else:
+                decoded = urllib.parse.unquote(data)
+
+            if decoded.strip().startswith('BEGIN:VCALENDAR'):
+                return decoded
+        except Exception as e:
+            print(f"Error extracting ICS content: {e}")
+
+        return None
+
+    def _send_email_with_ics_attachment(
+            self,
+            email_details: SendEmailRequestBody,
+            body: str,
+            event_name: str,
+            ics_content: str
+    ):
+        """
+        Send email with ICS file as attachment.
+        """
+        provider = email_details.provider
+        sender = self.email_sender.get(provider)
+
+        # Sanitize filename
+        safe_filename = ''.join(c for c in event_name if c.isalnum() or c in (' ', '-', '_')).strip()
+        safe_filename = safe_filename[:50] if safe_filename else 'event'
+        filename = f"{safe_filename}.ics"
+
+        # Check if sender supports attachments
+        if hasattr(sender, 'send_email_with_attachment'):
+            result = sender.send_email_with_attachment(
+                to_email=email_details.recipient,
+                subject=email_details.subject,
+                body=body,
+                cc=email_details.cc,
+                bcc=email_details.bcc,
+                is_html=True,
+                attachment_content=ics_content,
+                attachment_filename=filename,
+                attachment_content_type='text/calendar'
+            )
+        else:
+            # Fallback to regular email if attachment not supported
+            print(f"Warning: {provider} sender doesn't support attachments, sending without ICS file")
+            result = sender.send_email(
+                to_email=email_details.recipient,
+                subject=email_details.subject,
+                body=body,
+                cc=email_details.cc,
+                bcc=email_details.bcc,
+                is_html=True,
+            )
+
+        return result
 
     def _send_email_by_provider(self, email_details: SendEmailRequestBody, body: str):
         provider = email_details.provider

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -42,10 +42,9 @@ class EmailService:
                 )
                 if ics_content:
                     event_name = email_details.body.get('eventName', 'event')
-                    result = self._send_email_with_ics_attachment(
+                    return self._send_email_with_ics_attachment(
                         email_details, body, event_name, ics_content
                     )
-                    return result
             result = self._send_email_by_provider(email_details, body)
             return result
         except Exception as error:
@@ -58,20 +57,17 @@ class EmailService:
         """
         if not data_url or not data_url.startswith('data:'):
             return None
-
-        try:
-            header, data = data_url.split(',', 1)
-
-            if 'base64' in header:
-                decoded = base64.b64decode(data).decode('utf-8')
-            else:
-                decoded = urllib.parse.unquote(data)
-
-            if decoded.strip().startswith('BEGIN:VCALENDAR'):
-                return decoded
-        except Exception as e:
-            print(f"Error extracting ICS content: {e}")
-
+        
+        header, data = data_url.split(',', 1)
+        
+        if 'base64' in header:
+            decoded = base64.b64decode(data).decode('utf-8')
+        else:
+            decoded = urllib.parse.unquote(data)
+        
+        if decoded.strip().startswith('BEGIN:VCALENDAR'):
+            return decoded
+        
         return None
 
     def _send_email_with_ics_attachment(
@@ -87,14 +83,12 @@ class EmailService:
         provider = email_details.provider
         sender = self.email_sender.get(provider)
 
-        # Sanitize filename
         safe_filename = ''.join(c for c in event_name if c.isalnum() or c in (' ', '-', '_')).strip()
         safe_filename = safe_filename[:50] if safe_filename else 'event'
         filename = f"{safe_filename}.ics"
 
-        # Check if sender supports attachments
         if hasattr(sender, 'send_email_with_attachment'):
-            result = sender.send_email_with_attachment(
+            return sender.send_email_with_attachment(
                 to_email=email_details.recipient,
                 subject=email_details.subject,
                 body=body,
@@ -105,19 +99,15 @@ class EmailService:
                 attachment_filename=filename,
                 attachment_content_type='text/calendar'
             )
-        else:
-            # Fallback to regular email if attachment not supported
-            print(f"Warning: {provider} sender doesn't support attachments, sending without ICS file")
-            result = sender.send_email(
-                to_email=email_details.recipient,
-                subject=email_details.subject,
-                body=body,
-                cc=email_details.cc,
-                bcc=email_details.bcc,
-                is_html=True,
-            )
-
-        return result
+        
+        return sender.send_email(
+            to_email=email_details.recipient,
+            subject=email_details.subject,
+            body=body,
+            cc=email_details.cc,
+            bcc=email_details.bcc,
+            is_html=True,
+        )
 
     def _send_email_by_provider(self, email_details: SendEmailRequestBody, body: str):
         provider = email_details.provider

--- a/app/utils/email_sender.py
+++ b/app/utils/email_sender.py
@@ -8,6 +8,9 @@ from email.message import EmailMessage
 from typing import List
 
 from pydantic import EmailStr
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.mime.application import MIMEApplication
 
 
 class EmailSender:
@@ -102,6 +105,12 @@ class SESEmailSender:
         self.aws_secret_key = aws_secret_key
         self.aws_region = aws_region
         self.aws_email = aws_email
+        self.ses_client = boto3.client(
+            "ses",
+            region_name=self.aws_region,
+            aws_access_key_id=self.aws_access_key,
+            aws_secret_access_key=self.aws_secret_key,
+        )
 
     def send_email(
         self,
@@ -113,12 +122,6 @@ class SESEmailSender:
         is_html: bool = False,
     ) -> dict:
         try:
-            ses_client = boto3.client(
-                "ses",
-                region_name=self.aws_region,
-                aws_access_key_id=self.aws_access_key,
-                aws_secret_access_key=self.aws_secret_key,
-            )
             message = {"Subject": {"Data": subject}, "Body": {}}
             if is_html:
                 message["Body"]["Html"] = {"Data": body}
@@ -137,3 +140,68 @@ class SESEmailSender:
             return {"success": True, "message_id": response["MessageId"]}
         except Exception as error:
             raise ConnectionError(f"Email sending failed: {str(error)}") from error
+
+    def send_email_with_attachment(
+        self,
+        to_email: str,
+        subject: str,
+        body: str,
+        attachment_content: str,
+        attachment_filename: str,
+        attachment_content_type: str = 'application/octet-stream',
+        cc: List[EmailStr] = None,
+        bcc: List[EmailStr] = None,
+        is_html: bool = True,
+    ) -> dict:
+        """
+        Sends an email with an attachment (like an ICS file) using AWS SES send_raw_email.
+        """
+        try:
+            msg = MIMEMultipart()
+            msg['Subject'] = subject
+            msg['From'] = self.aws_email
+            msg['To'] = to_email
+
+            if cc:
+                msg['Cc'] = ", ".join(cc)
+            if bcc:
+                msg['Bcc'] = ", ".join(bcc)
+
+            body_type = 'html' if is_html else 'plain'
+            msg.attach(MIMEText(body, body_type))
+
+            if isinstance(attachment_content, str):
+                attachment_data = attachment_content.encode('utf-8')
+            else:
+                attachment_data = attachment_content
+
+            part = MIMEApplication(attachment_data)
+            
+            part.add_header(
+                'Content-Disposition', 
+                'attachment', 
+                filename=attachment_filename
+            )
+            
+            if attachment_content_type:
+                part.add_header('Content-Type', attachment_content_type)
+
+            msg.attach(part)
+
+            destinations = [to_email]
+            if cc:
+                destinations.extend(cc)
+            if bcc:
+                destinations.extend(bcc)
+
+            response = self.ses_client.send_raw_email(
+                Source=self.aws_email,
+                Destinations=destinations,
+                RawMessage={
+                    'Data': msg.as_string(),
+                }
+            )
+            return {'success': True, 'message_id': response['MessageId']}
+
+        except Exception as error:
+            raise ConnectionError(f"Email with attachment failed: {str(error)}") from error

--- a/templates/rsvp/ticket.html
+++ b/templates/rsvp/ticket.html
@@ -118,22 +118,6 @@
                                   </td>
                                 </tr>
                                 <tr>
-                                  <td style="padding: 10px 20px; border-bottom: 1px solid #2d2d2f;">
-                                    <a href="{{iCalendarLink}}" target="_blank" style="text-decoration: none; display: block;">
-                                      <table border="0" cellpadding="0" cellspacing="0" width="200" align="center">
-                                        <tr>
-                                          <td style="width: 32px; text-align: center; vertical-align: middle;">
-                                            <img width="24" height="24" src="https://img.icons8.com/color/48/calendar-app.png" style="display: inline-block;"/>
-                                          </td>
-                                          <td style="vertical-align: middle; text-align: left; padding-left: 12px;">
-                                            <span style="color: #e5e5e7; font-size: 14px; font-weight: 500;">iCal</span>
-                                          </td>
-                                        </tr>
-                                      </table>
-                                    </a>
-                                  </td>
-                                </tr>
-                                <tr>
                                   <td style="padding: 10px 20px; border-radius: 0 0 20px 20px;">
                                     <a href="{{outlookCalendarLink}}" target="_blank" style="text-decoration: none; display: block;">
                                       <table border="0" cellpadding="0" cellspacing="0" width="200" align="center">


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->

This PR resolves the issue where users could not download the calendar invite in confirmation emails. The implementation has been changed from a data: URI link to sending the .ics file as a standard email attachment.

- Fixes: https://github.com/TeamShiksha/rsvp/issues/687

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->


https://github.com/user-attachments/assets/45f942ec-7ada-4d84-8f31-f70df98bd264



## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
