### PR TITLE
feat: add Autosend as an opt-in email provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.claude*

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ For environment validation and constants
 
 import os
 from typing import cast
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 SWAGGER_APP_DESCRIPTION = """
@@ -46,6 +46,11 @@ class Config(BaseSettings):
     Environmental variable validation class.
     """
 
+    # Read .env here rather than relying on run.py's load_dotenv(), which runs
+    # after this class is instantiated at import time. Real environment
+    # variables still take precedence, so hosted deployments are unaffected.
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
     EMAIL_PORT: int = cast(int, os.getenv("EMAIL_PORT", "587"))
     EMAIL_HOST: str = cast(str, os.getenv("EMAIL_HOST", "smtp.gmail.com"))
     EMAIL_ADDRESS: str = cast(str, os.getenv("EMAIL_ADDRESS"))
@@ -60,5 +65,12 @@ class Config(BaseSettings):
     AWS_ACCESS_KEY: str = cast(str, os.getenv("AWS_USER_ACCESS_KEY"))
     AWS_REGION: str = cast(str, os.getenv("AWS_REGION"))
     AWS_EMAIL: str = cast(str, os.getenv("AWS_EMAIL"))
+
+    AUTOSEND_API_KEY: str = cast(str, os.getenv("AUTOSEND_API_KEY", ""))
+    AUTOSEND_FROM_EMAIL: str = cast(str, os.getenv("AUTOSEND_FROM_EMAIL", ""))
+    AUTOSEND_FROM_NAME: str = cast(str, os.getenv("AUTOSEND_FROM_NAME", ""))
+    AUTOSEND_BASE_URL: str = cast(
+        str, os.getenv("AUTOSEND_BASE_URL", "https://api.autosend.com/v1")
+    )
 
 config = Config()

--- a/app/routers/email_router.py
+++ b/app/routers/email_router.py
@@ -12,6 +12,7 @@ from app.schemas.email import SendEmailRequestBody, SendEmailResponseBody, Email
 from app.utils import (
     EmailSender,
     SESEmailSender,
+    AutosendEmailSender,
     success_response,
     get_email_sender,
     require_authentication,
@@ -27,9 +28,9 @@ templates = Jinja2Templates(directory="templates")
 async def send_email(
     request: Request,
     email_details: SendEmailRequestBody,
-    email_sender: Dict[EmailProvider, Union[EmailSender, SESEmailSender]] = Depends(
-        get_email_sender
-    ),
+    email_sender: Dict[
+        EmailProvider, Union[EmailSender, SESEmailSender, AutosendEmailSender]
+    ] = Depends(get_email_sender),
 ):
     """
     Sends an email to the recipient using provided details.

--- a/app/schemas/email.py
+++ b/app/schemas/email.py
@@ -12,6 +12,7 @@ from app.config import config
 class EmailProvider(str, Enum):
     GMAIL = "GMAIL"
     SES = "SES"
+    AUTOSEND = "AUTOSEND"
 
 
 class SendEmailRequestBody(BaseModel):

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -7,7 +7,7 @@ from typing import Dict, Union
 from smtplib import SMTPException, SMTPAuthenticationError, SMTPSenderRefused
 import botocore.exceptions
 
-from app.utils import EmailSender, SESEmailSender
+from app.utils import EmailSender, SESEmailSender, AutosendEmailSender
 from app.schemas.email import SendEmailRequestBody, EmailProvider
 import base64
 import urllib.parse
@@ -19,7 +19,10 @@ class EmailService:
     """
 
     def __init__(
-        self, email_sender: Dict[EmailProvider, Union[EmailSender, SESEmailSender]]
+        self,
+        email_sender: Dict[
+            EmailProvider, Union[EmailSender, SESEmailSender, AutosendEmailSender]
+        ],
     ):
         self.email_sender = email_sender
 
@@ -124,7 +127,8 @@ class EmailService:
 
     def _handle_email_error(self, error: Exception):
         if isinstance(
-            error, (SMTPAuthenticationError, botocore.exceptions.ClientError)
+            error,
+            (PermissionError, SMTPAuthenticationError, botocore.exceptions.ClientError),
         ):
             raise PermissionError(f"Authentication failed: {str(error)}") from error
         elif isinstance(error, SMTPSenderRefused):

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,4 +1,4 @@
-from .email_sender import EmailSender, SESEmailSender
+from .email_sender import EmailSender, SESEmailSender, AutosendEmailSender
 from .dependencies import require_authentication, get_email_sender
 from .response import error_response, success_response
 from .exceptions import custom_http_exception_handler, custom_general_exception_handler

--- a/app/utils/dependencies.py
+++ b/app/utils/dependencies.py
@@ -7,7 +7,7 @@ from typing import Dict, Union
 from fastapi import HTTPException, Request
 from app.config import config
 from app.schemas.email import EmailProvider
-from .email_sender import EmailSender, SESEmailSender
+from .email_sender import EmailSender, SESEmailSender, AutosendEmailSender
 
 
 def require_authentication():
@@ -29,7 +29,9 @@ def require_authentication():
     return decorator
 
 
-def get_email_sender() -> Dict[EmailProvider, Union[EmailSender, SESEmailSender]]:
+def get_email_sender() -> (
+    Dict[EmailProvider, Union[EmailSender, SESEmailSender, AutosendEmailSender]]
+):
     """
     Creates and returns a dictionary of email sender objects.
     This function is used as a dependency injection in the controller.
@@ -48,4 +50,15 @@ def get_email_sender() -> Dict[EmailProvider, Union[EmailSender, SESEmailSender]
         aws_email=config.AWS_EMAIL,
     )
 
-    return {EmailProvider.GMAIL: gmail_sender, EmailProvider.SES: ses_sender}
+    autosend_sender = AutosendEmailSender(
+        api_key=config.AUTOSEND_API_KEY,
+        from_email=config.AUTOSEND_FROM_EMAIL,
+        from_name=config.AUTOSEND_FROM_NAME,
+        base_url=config.AUTOSEND_BASE_URL,
+    )
+
+    return {
+        EmailProvider.GMAIL: gmail_sender,
+        EmailProvider.SES: ses_sender,
+        EmailProvider.AUTOSEND: autosend_sender,
+    }

--- a/app/utils/email_sender.py
+++ b/app/utils/email_sender.py
@@ -2,10 +2,12 @@
 For third party email sender.
 """
 
+import base64
 import smtplib
 import boto3
+import requests
 from email.message import EmailMessage
-from typing import List
+from typing import List, Optional
 
 from pydantic import EmailStr
 from email.mime.multipart import MIMEMultipart
@@ -205,3 +207,145 @@ class SESEmailSender:
 
         except Exception as error:
             raise ConnectionError(f"Email with attachment failed: {str(error)}") from error
+
+
+class AutosendEmailSender:
+    """
+    A helper class for sending emails using the Autosend REST API.
+
+    Mirrors the interface of SESEmailSender so the service layer can swap
+    between providers without changes. See https://docs.autosend.com/.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        from_email: str,
+        from_name: str = "",
+        base_url: str = "https://api.autosend.com/v1",
+        timeout: int = 30,
+    ):
+        self.api_key = api_key
+        self.from_email = from_email
+        self.from_name = from_name
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _sender(self) -> dict:
+        sender = {"email": self.from_email}
+        if self.from_name:
+            sender["name"] = self.from_name
+        return sender
+
+    @staticmethod
+    def _as_recipients(emails: Optional[List[EmailStr]]) -> List[dict]:
+        return [{"email": str(email)} for email in emails or []]
+
+    def _build_destination(
+        self,
+        to_email: Optional[str],
+        cc: Optional[List[EmailStr]],
+        bcc: Optional[List[EmailStr]],
+    ) -> dict:
+        """
+        Builds the to/cc/bcc portion of the payload.
+
+        Autosend requires a `to` recipient, while SES accepted a cc/bcc-only
+        send. When there is no recipient the first cc is promoted, since cc is
+        already visible to everyone; a bcc is never promoted as that would
+        expose a blind recipient.
+        """
+        cc_list = self._as_recipients(cc)
+        bcc_list = self._as_recipients(bcc)
+
+        if to_email:
+            to = {"email": str(to_email)}
+        elif cc_list:
+            to = cc_list.pop(0)
+        else:
+            to = self._sender()
+
+        destination = {"to": to}
+        if cc_list:
+            destination["cc"] = cc_list
+        if bcc_list:
+            destination["bcc"] = bcc_list
+        return destination
+
+    def _post(self, payload: dict) -> dict:
+        try:
+            response = requests.post(
+                f"{self.base_url}/mails/send",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=self.timeout,
+            )
+        except requests.RequestException as error:
+            raise ConnectionError(f"Email sending failed: {str(error)}") from error
+
+        if response.status_code in (401, 403):
+            raise PermissionError(
+                f"Authentication failed: {response.status_code} {response.text}"
+            )
+        if response.status_code >= 400:
+            raise ConnectionError(
+                f"Email sending failed: {response.status_code} {response.text}"
+            )
+
+        data = response.json().get("data", {})
+        return {"success": True, "message_id": data.get("emailId")}
+
+    def send_email(
+        self,
+        to_email: str,
+        subject: str,
+        body: str,
+        cc: List[EmailStr],
+        bcc: List[EmailStr],
+        is_html: bool = False,
+    ) -> dict:
+        payload = {
+            "from": self._sender(),
+            "subject": subject,
+            **self._build_destination(to_email, cc, bcc),
+        }
+        payload["html" if is_html else "text"] = body
+        return self._post(payload)
+
+    def send_email_with_attachment(
+        self,
+        to_email: str,
+        subject: str,
+        body: str,
+        attachment_content: str,
+        attachment_filename: str,
+        attachment_content_type: str = "application/octet-stream",
+        cc: List[EmailStr] = None,
+        bcc: List[EmailStr] = None,
+        is_html: bool = True,
+    ) -> dict:
+        """
+        Sends an email with an attachment (like an ICS file) using Autosend.
+        """
+        if isinstance(attachment_content, str):
+            attachment_data = attachment_content.encode("utf-8")
+        else:
+            attachment_data = attachment_content
+
+        payload = {
+            "from": self._sender(),
+            "subject": subject,
+            "attachments": [
+                {
+                    "fileName": attachment_filename,
+                    "content": base64.b64encode(attachment_data).decode("utf-8"),
+                    "contentType": attachment_content_type,
+                }
+            ],
+            **self._build_destination(to_email, cc, bcc),
+        }
+        payload["html" if is_html else "text"] = body
+        return self._post(payload)

--- a/env_example
+++ b/env_example
@@ -10,3 +10,7 @@ AWS_SECRET_KEY=somesecretkey
 AWS_ACCESS_KEY=someaccesskey
 AWS_REGION=someregion
 AWS_EMAIL=awsverifiedemail
+AUTOSEND_API_KEY=AS_yourprojectapikey
+AUTOSEND_FROM_EMAIL=verified@yourdomain.com
+AUTOSEND_FROM_NAME=Team Shiksha
+AUTOSEND_BASE_URL=https://api.autosend.com/v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ uvicorn==0.32.0
 watchfiles==0.24.0
 websockets==13.1
 boto3>=1.37.27
+requests>=2.32.3


### PR DESCRIPTION
## What

Adds [Autosend](https://docs.autosend.com/) as a third email provider alongside AWS SES and Gmail SMTP.

**SES remains the default.** Callers opt in per request by passing `"provider": "AUTOSEND"`. Any caller that omits the field is completely unaffected, so this ships with zero behaviour change and each downstream project (openlogo, rsvp, teamshiksha, swags.me) can migrate on its own schedule.

## Changes

| File | Change |
|---|---|
| `app/utils/email_sender.py` | New `AutosendEmailSender`, mirroring `SESEmailSender`'s interface (`send_email`, `send_email_with_attachment`) |
| `app/utils/dependencies.py` | Registers the provider under `EmailProvider.AUTOSEND` |
| `app/schemas/email.py` | Adds `AUTOSEND` to the `EmailProvider` enum |
| `app/services/email_service.py` | Maps `PermissionError` to a 403 (see below) |
| `app/config.py` | Adds `AUTOSEND_*` settings, and fixes `.env` loading (see below) |
| `requirements.txt` | Adds `requests` |
| `env_example` | Documents the new variables |

`SESEmailSender` is untouched.

## Two fixes included

**`.env` was never being loaded.** `run.py` imports `config` on line 8, which instantiates `Config()` at import time, but `load_dotenv()` doesn't run until line 11. A valid `.env` produced eight missing-variable errors on startup. `Config` now reads `.env` directly via `SettingsConfigDict(env_file=".env")`. Real environment variables still take precedence, so hosted deployments are unaffected. This affected `APP_SECRET` and `AWS_*` too, not just Autosend.

**Auth failures returned 500 instead of 403.** `_handle_email_error` only mapped SMTP and botocore auth errors to `PermissionError`; an Autosend `401`/`403` fell through to `ConnectionError` and surfaced as a 500. Neither `SESEmailSender` nor `EmailSender` raises `PermissionError`, so SES and Gmail error mapping is unchanged.

## Verification

Live sends through the new provider, rendered from the existing templates:

**Welcome (template ID 9)**

![Welcome email delivered via Autosend](https://raw.githubusercontent.com/TeamShiksha/email-service/assets/autosend-screenshots/.github/pr-assets/autosend-welcome-email.png)

**Assignment (template ID 12)**

![Assignment email delivered via Autosend](https://raw.githubusercontent.com/TeamShiksha/email-service/assets/autosend-screenshots/.github/pr-assets/autosend-assignment-email.png)

Also checked:

- Existing callers still route to SES — `provider` omitted, `SES`, and `GMAIL` all resolve as before
- All 14 templates still validate and render
- Response shape unchanged (`{success, message, details}`)
- Wrong auth → 401, bad provider casing → 422, missing body key → 422
- Pylint 8.81 (baseline 8.56)

## Deploy note

`requests` is a new dependency — dependencies must be reinstalled or the service will fail to boot with `ModuleNotFoundError`.

New environment variables (all optional; the app boots without them and only Autosend sends fail):

```
AUTOSEND_API_KEY=
AUTOSEND_FROM_EMAIL=      # must be on a domain verified in Autosend
AUTOSEND_FROM_NAME=
AUTOSEND_BASE_URL=        # defaults to https://api.autosend.com/v1
```

## Known limits for anyone migrating a caller

- **50 recipients per request** (combined to+cc+bcc), enforced by Autosend. Amazon SES has the same limit, so this ceiling already exists today.
- **300 emails/day**, scoped per sending domain and shared by every project sending from `teamshiksha.com`. It rises automatically with healthy sending.
- **2 requests/second** per API key, returning `429`.

## Follow-ups (deliberately not in this PR)

- `429` is not handled distinctly and `retryAfter` is discarded
- Provider error text is passed through to callers in the response detail
- No pre-flight guard on the 50-recipient cap
- Pre-existing: omitting `recipient` entirely (with no cc/bcc) returns 500 rather than 422, because the validator only fires when the key is present but null

---

Screenshots are hosted on the `assets/autosend-screenshots` branch so they are not merged into `prod`.
